### PR TITLE
Add mockito into dependencies

### DIFF
--- a/src/supernode/pom.xml
+++ b/src/supernode/pom.xml
@@ -41,6 +41,12 @@
 
     <dependencies>
         <dependency>
+           <groupId>org.mockito</groupId>
+           <artifactId>mockito-all</artifactId>
+           <version>1.10.19</version>
+           <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <exclusions>


### PR DESCRIPTION
Add mockito a the start of the dependencies. At the moment, we
transitively use a different (wrong) mockito version through another
dependency. Adding the right version at the start should override
the current behaviour.