### PR TITLE
Disable static value retriever in mocking phases

### DIFF
--- a/diffblue.yml
+++ b/diffblue.yml
@@ -67,6 +67,7 @@ phases:
       throw-runtime-exceptions: true
       unwind: false
   - timeout: 150
+    staticValuesJson: false
     cbmcArguments:
       classpath: '/tools/cbmc/models-simple-overlay.jar:/tools/cbmc/models.jar:.'
       depth: 1500
@@ -78,6 +79,7 @@ phases:
       throw-runtime-exceptions: false
       unwind: 1
   - timeout: 150
+    staticValuesJson: false
     cbmcArguments:
       classpath: '/tools/cbmc/models.jar:.'
       depth: 3000
@@ -89,6 +91,7 @@ phases:
       throw-runtime-exceptions: true
       unwind: 3
   - timeout: 150
+    staticValuesJson: false
     cbmcArguments:
       classpath: '/tools/cbmc/models.jar:.'
       depth: 3000
@@ -100,6 +103,7 @@ phases:
       throw-runtime-exceptions: false
       unwind: 15
   - timeout: 150
+    staticValuesJson: false
     cbmcArguments:
       classpath: '/tools/cbmc/models-simple-overlay.jar:/tools/cbmc/models.jar:.'
       depth: 1500
@@ -111,6 +115,7 @@ phases:
       throw-runtime-exceptions: false
       unwind: 1
   - timeout: 150
+    staticValuesJson: false
     cbmcArguments:
       classpath: '/tools/cbmc/models.jar:.'
       depth: 3000


### PR DESCRIPTION
This is another temporary and experimental change: we only use the value retriever in the phases that don't use --load-containing-class-only or --single-function-only.
We don't have tests for using the retriever with one of these two options, so it will be interesting to see if this affects coverage.

At the top level the `staticValuesJson: true` option still needs to be enabled so that the JSON file can be uploaded by the master job.